### PR TITLE
"Show Deprecated" filtering option

### DIFF
--- a/_includes/components/filter.html
+++ b/_includes/components/filter.html
@@ -1,4 +1,9 @@
 <div class="controls">
   <label class="controls__label" for="filter-input">Find a client</label>
   <input class="controls__input" type="text" placeholder="e.g. Outlook" id="filter-input">
+
+  <div class="controls__checkbox-wrapper">
+    <input type="checkbox" id="filter-deprecated">
+    <label for="filter-deprecated">Show Deprecated</label>
+  </div>
 </div>

--- a/_includes/components/hack.html
+++ b/_includes/components/hack.html
@@ -1,7 +1,7 @@
 {% assign anchor = hack.date | date: "%Y-%m-%d"| append: "-" | append: hack.slug %}
 {% assign contributor = site.data.contributors[hack.contributor] %}
 
-<article class="hack" id="{{ anchor }}">
+<article class="hack hack--{{ hack.status | downcase }}" id="{{ anchor }}">
   <div class="hack__heading">
     <h2 class="hack__client">
       {{ hack.client }} {{ hack.version }}

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -22,6 +22,14 @@ searchInput.addEventListener("keyup", () => {
   liveSearch();
 });
 
+// toggle deprecated hacks
+let deprecatedCheckbox = document.getElementById("filter-deprecated");
+let hacksWrapper = document.querySelector('.hacks');
+
+deprecatedCheckbox.addEventListener("change", () => {
+  hacksWrapper.classList.toggle('hacks--show-deprecated', deprecatedCheckbox.checked);
+});
+
 // Copy button
 const codeBlocks = document.querySelectorAll(
   ".copy-button + .highlighter-rouge"

--- a/assets/scss/components/_filter.scss
+++ b/assets/scss/components/_filter.scss
@@ -27,3 +27,15 @@
 		color: var(--color-fg-secondary);
 	}
 }
+
+.controls__checkbox-wrapper {
+	margin-top: var(--spacing-sm);
+
+	input, label {
+		vertical-align: middle;
+	}
+
+	label {
+		margin-left: var(--spacing-xs);
+	}
+}

--- a/assets/scss/components/_hack.scss
+++ b/assets/scss/components/_hack.scss
@@ -81,3 +81,7 @@
     text-decoration: underline;
   }
 }
+
+.hacks:not(.hacks--show-deprecated) .hack--deprecated {
+  display: none;
+}


### PR DESCRIPTION
This PR:

- hides deprecated hacks by default 
- adds a filtering option (checkbox) to toggle deprecated hacks

`.hacks .hack--deprecated` is hidden unless `.hacks` has the `.hacks--show-deprecated` modifier class. Feels a little unintuitive, but matches the JS logic. I'm happy to change this to use `.hacks--hide-deprecated` instead.

---

The motivation behind this is reduce noise. A developer looking for a targeting hack would probably want something that works now. 

Having said that I can see developers wanting to check deprecated hacks to clean up older templates. So perhaps a checkbox per status (so the user can control what is included) is a better approach?
