### PR TITLE
Unify hack CSS format

### DIFF
--- a/hacks/_posts/2019-03-01-newton-desktop.md
+++ b/hacks/_posts/2019-03-01-newton-desktop.md
@@ -9,5 +9,5 @@ contributor: Mark Robbins
 ---
 
 ```css
-#cm_mail_smart_body .foo
+#cm_mail_smart_body .foo {}
 ```

--- a/hacks/_posts/2019-03-26-airmail.md
+++ b/hacks/_posts/2019-03-26-airmail.md
@@ -9,5 +9,5 @@ contributor: Mark Robbins
 ---
 
 ```css
-.bloop_container .foo
+.bloop_container .foo {}
 ```

--- a/hacks/_posts/2019-03-26-android-2.3.md
+++ b/hacks/_posts/2019-03-26-android-2.3.md
@@ -9,7 +9,7 @@ contributor: Mark Robbins
 ---
 
 ```css
-@media screen and (min-width:0\0){ .foo }
+@media screen and (min-width:0\0){ .foo {} }
 ```
 
 This broken media query will also show in Outlook 00–03 so you may need to add an IE conditional comment.

--- a/hacks/_posts/2019-03-26-android-2.md
+++ b/hacks/_posts/2019-03-26-android-2.md
@@ -9,5 +9,5 @@ contributor: Mark Robbins
 ---
 
 ```css
-@media screen and (pointer) { .foo}
+@media screen and (pointer) { .foo {} }
 ```

--- a/hacks/_posts/2019-03-26-android-4.2.md
+++ b/hacks/_posts/2019-03-26-android-4.2.md
@@ -9,7 +9,7 @@ contributor: Mark Robbins
 ---
 
 ```css
-_:-webkit-full-screen, :root .foo
+_:-webkit-full-screen, :root .foo {}
 ```
 
 This won’t render on iOS devices but will render on desktop so may need a `max-device-width` media query.

--- a/hacks/_posts/2019-03-26-android-4.4.md
+++ b/hacks/_posts/2019-03-26-android-4.4.md
@@ -9,7 +9,7 @@ contributor: Mark Robbins
 ---
 
 ```css
-_:-webkit-full-screen, :root .foo
+_:-webkit-full-screen, :root .foo {}
 ```
 
 This won’t render on iOS devices but will render on desktop so may need a `max-device-width` media query.

--- a/hacks/_posts/2019-03-26-android.md
+++ b/hacks/_posts/2019-03-26-android.md
@@ -9,5 +9,5 @@ contributor: Mark Robbins
 ---
 
 ```css
-_:-webkit-full-screen, :root .foo
+_:-webkit-full-screen, :root .foo {}
 ```

--- a/hacks/_posts/2019-03-26-aol.md
+++ b/hacks/_posts/2019-03-26-aol.md
@@ -9,7 +9,7 @@ contributor: Mark Robbins
 ---
 
 ```css
-.body
+.body {}
 ```
 
 AOL also removes class from the body tag so you can use `.body` to avoid AOL.

--- a/hacks/_posts/2019-03-26-apple-mail-10.md
+++ b/hacks/_posts/2019-03-26-apple-mail-10.md
@@ -9,5 +9,5 @@ contributor: Mark Robbins
 ---
 
 ```css
-.Singleton .foo
+.Singleton .foo {}
 ```

--- a/hacks/_posts/2019-03-26-apple-mail-12.4.md
+++ b/hacks/_posts/2019-03-26-apple-mail-12.4.md
@@ -9,7 +9,7 @@ contributor: Mark Robbins
 ---
 
 ```css
-[class^="apple-mail"] .foo
+[class^="apple-mail"] .foo {}
 ```
 
 Also targets iOS 13.

--- a/hacks/_posts/2019-03-26-apple-mail-8.md
+++ b/hacks/_posts/2019-03-26-apple-mail-8.md
@@ -9,5 +9,5 @@ contributor: Mark Robbins
 ---
 
 ```css
-_:-webkit-full-screen, _::-webkit-full-page-media, _:future, :root .foo
+_:-webkit-full-screen, _::-webkit-full-page-media, _:future, :root .foo {}
 ```

--- a/hacks/_posts/2019-03-26-edison-android.md
+++ b/hacks/_posts/2019-03-26-edison-android.md
@@ -9,5 +9,5 @@ contributor: Mark Robbins
 ---
 
 ```css
-.edo-email-view .foo
+.edo-email-view .foo {}
 ```

--- a/hacks/_posts/2019-03-26-edison-ios.md
+++ b/hacks/_posts/2019-03-26-edison-ios.md
@@ -9,5 +9,5 @@ contributor: Mark Robbins
 ---
 
 ```css
-.edo .foo
+.edo .foo {}
 ```

--- a/hacks/_posts/2019-03-26-edison.md
+++ b/hacks/_posts/2019-03-26-edison.md
@@ -9,7 +9,7 @@ contributor: Mark Robbins
 ---
 
 ```css
-#edo-container .foo
+#edo-container .foo {}
 ```
 
 Will cover both iOS and Android.

--- a/hacks/_posts/2019-03-26-freenet-2.md
+++ b/hacks/_posts/2019-03-26-freenet-2.md
@@ -9,8 +9,8 @@ contributor: Mark Robbins
 ---
 
 ```css
-meta ~ * .foo
-title ~ * .foo
+meta ~ * .foo {}
+title ~ * .foo {}
 ```
 
 The head and body structure of the email is removed, making content in the head, siblings of that in the body, so we can target with this. Applies to Thunderbird, Freenet (`title` element only), Orange.fr, and Samsung.

--- a/hacks/_posts/2019-03-26-freenet.md
+++ b/hacks/_posts/2019-03-26-freenet.md
@@ -9,5 +9,5 @@ contributor: Mark Robbins
 ---
 
 ```css
-#msgBody .foo
+#msgBody .foo {}
 ```

--- a/hacks/_posts/2019-03-26-gmail-android.md
+++ b/hacks/_posts/2019-03-26-gmail-android.md
@@ -9,7 +9,7 @@ contributor: Mark Robbins
 ---
 
 ```css
-div > u + .body .foo
+div > u + .body .foo {}
 ```
 
 Gmail changes the doctype to `<u></u>`. This is placed adjacent to a div that inherits class and id from the body tag.

--- a/hacks/_posts/2019-03-26-gmail.md
+++ b/hacks/_posts/2019-03-26-gmail.md
@@ -9,7 +9,7 @@ contributor: Mark Robbins
 ---
 
 ```css
-u + .body .foo
+u + .body .foo {}
 ```
 
 Gmail changes the doctype to `<u></u>`. This is placed adjacent to a div that inherits class and id from the body tag.

--- a/hacks/_posts/2019-03-26-gmx-web.de-2.md
+++ b/hacks/_posts/2019-03-26-gmx-web.de-2.md
@@ -9,5 +9,5 @@ contributor: Mark Robbins
 ---
 
 ```css
-body[style*="overflow-wrap:break-word"]
+body[style*="overflow-wrap:break-word"] {}
 ```

--- a/hacks/_posts/2019-03-26-gmx-web.de.md
+++ b/hacks/_posts/2019-03-26-gmx-web.de.md
@@ -9,7 +9,7 @@ contributor: Mark Robbins
 ---
 
 ```css
-u + .body .foo
+u + .body .foo {}
 ```
 
 Any class or ID name prefixed with an unsupported character will kill all the styles following it.

--- a/hacks/_posts/2019-03-26-ios-mail-10.md
+++ b/hacks/_posts/2019-03-26-ios-mail-10.md
@@ -9,5 +9,5 @@ contributor: Mark Robbins
 ---
 
 ```css
-@supports (-webkit-overflow-scrolling:touch) and (color:#ffff) { .foo }
+@supports (-webkit-overflow-scrolling:touch) and (color:#ffff) { .foo {} }
 ```

--- a/hacks/_posts/2019-03-26-nine.md
+++ b/hacks/_posts/2019-03-26-nine.md
@@ -9,7 +9,7 @@ contributor: Mark Robbins
 ---
 
 ```css
-.body > div > div > .wrapper .foo
+.body > div > div > .wrapper .foo {}
 ```
 
 Nine inserts a couple of divs between the body and the wrapper. Same hack also targets Samsung and possibly others.

--- a/hacks/_posts/2019-03-26-notes-8.md
+++ b/hacks/_posts/2019-03-26-notes-8.md
@@ -9,7 +9,7 @@ contributor: Mark Robbins
 ---
 
 ```css
-.unused.foo
+.unused.foo {}
 ```
 
 Notes 8 will strip the unrecognised class and render the code behind it.

--- a/hacks/_posts/2019-03-26-open-xchange.md
+++ b/hacks/_posts/2019-03-26-open-xchange.md
@@ -9,7 +9,7 @@ contributor: Mark Robbins
 ---
 
 ```css
-.foo[class^="ox-"]
+.foo[class^="ox-"] {}
 ```
 
 Open-Xchange powers a number of different email clients including Comcast, Libero, 1&1 MailXchange, Network Solutions Secure Mail, Namecheap Email Hosting, Mailbox.org, 123-reg Email, acens Correo Professional, Home.pl Cloud Email Xchange, Virgin Media Mail, and Ziggo Mail.

--- a/hacks/_posts/2019-03-26-orange.md
+++ b/hacks/_posts/2019-03-26-orange.md
@@ -9,8 +9,8 @@ contributor: Mark Robbins
 ---
 
 ```css
-meta ~ * .foo
-title ~ * .foo
+meta ~ * .foo {}
+title ~ * .foo {}
 ```
 
 The head and body structure of the email is removed, making content in the head siblings of that in the body, so we can target with this. Applies to Thunderbird, Freenet (`title` element only), Orange.fr, and Samsung.

--- a/hacks/_posts/2019-03-26-outlook-macos.md
+++ b/hacks/_posts/2019-03-26-outlook-macos.md
@@ -9,7 +9,7 @@ contributor: Mark Robbins
 ---
 
 ```css
-_:-webkit-full-screen, _::-webkit-full-page-media, _:future, :root body:not(.Singleton) .foo
+_:-webkit-full-screen, _::-webkit-full-page-media, _:future, :root body:not(.Singleton) .foo {}
 ```
 
 The stuff before `.body` will target WebKit desktop apps on Mac (Apple Mail and Outlook Mac), then we add `:not(.Singleton)` to remove Apple Mail.

--- a/hacks/_posts/2019-03-26-outlook-webmail.md
+++ b/hacks/_posts/2019-03-26-outlook-webmail.md
@@ -9,5 +9,5 @@ contributor: Mark Robbins
 ---
 
 ```css
-[owa].foo x:default .foo
+[owa].foo x:default .foo {}
 ```

--- a/hacks/_posts/2019-03-26-postbox.md
+++ b/hacks/_posts/2019-03-26-postbox.md
@@ -9,5 +9,5 @@ contributor: Mark Robbins
 ---
 
 ```css
-.moz-text-html .foo
+.moz-text-html .foo {}
 ```

--- a/hacks/_posts/2019-03-26-samsung-email-s4.md
+++ b/hacks/_posts/2019-03-26-samsung-email-s4.md
@@ -9,5 +9,5 @@ contributor: Mark Robbins
 ---
 
 ```css
-#secdiv
+#secdiv {}
 ```

--- a/hacks/_posts/2019-03-26-samsung-email-s5-s9-2.md
+++ b/hacks/_posts/2019-03-26-samsung-email-s5-s9-2.md
@@ -9,5 +9,5 @@ contributor: Mark Robbins
 ---
 
 ```css
-#MessageViewBody
+#MessageViewBody {}
 ```

--- a/hacks/_posts/2019-03-26-samsung-email-s5-s9-3.md
+++ b/hacks/_posts/2019-03-26-samsung-email-s5-s9-3.md
@@ -9,7 +9,7 @@ contributor: Mark Robbins
 ---
 
 ```css
-.body > div > div > .wrapper .foo
+.body > div > div > .wrapper .foo {}
 ```
 
 Samsung inserts a couple of divs between the body and the wrapper. Same hack as Nine.

--- a/hacks/_posts/2019-03-26-samsung-email-s5-s9.md
+++ b/hacks/_posts/2019-03-26-samsung-email-s5-s9.md
@@ -9,6 +9,6 @@ contributor: Mark Robbins
 ---
 
 ```css
-meta ~ * .foo
-title ~ * .foo
+meta ~ * .foo {}
+title ~ * .foo {}
 ```

--- a/hacks/_posts/2019-03-26-spark.md
+++ b/hacks/_posts/2019-03-26-spark.md
@@ -9,7 +9,7 @@ contributor: Mark Robbins
 ---
 
 ```css
-_:-webkit-full-screen, _::-webkit-full-page-media, _:future, :root .body:not(.Singleton)
+_:-webkit-full-screen, _::-webkit-full-page-media, _:future, :root .body:not(.Singleton) {}
 ```
 
 Same target as Outlook for macOS.

--- a/hacks/_posts/2019-03-26-thunderbird-2.md
+++ b/hacks/_posts/2019-03-26-thunderbird-2.md
@@ -9,7 +9,7 @@ contributor: Mark Robbins
 ---
 
 ```css
-.moz-text-html .foo
+.moz-text-html .foo {}
 ```
 
 This class is placed on a div inserted between the body and the wrapper so you can also do something like `body > div > .wrapper .foo`.

--- a/hacks/_posts/2019-03-26-thunderbird.md
+++ b/hacks/_posts/2019-03-26-thunderbird.md
@@ -9,8 +9,8 @@ contributor: Mark Robbins
 ---
 
 ```css
-meta ~ * .foo
-title ~ * .foo
+meta ~ * .foo {}
+title ~ * .foo {}
 ```
 
 The head and body structure of the email is removed, making content in the head siblings of that in the body, so we can target with this. Applies to Thunderbird, Freenet (`title` element only), Orange.fr, and Samsung.

--- a/hacks/_posts/2019-03-26-windows-mail-2.md
+++ b/hacks/_posts/2019-03-26-windows-mail-2.md
@@ -9,5 +9,5 @@ contributor: Mark Robbins
 ---
 
 ```css
-_:-ms-fullscreen, :root .foo
+_:-ms-fullscreen, :root .foo {}
 ```

--- a/hacks/_posts/2019-03-26-windows-mail.md
+++ b/hacks/_posts/2019-03-26-windows-mail.md
@@ -9,5 +9,5 @@ contributor: Mark Robbins
 ---
 
 ```css
-_:-ms-input-placeholder, :root .foo
+_:-ms-input-placeholder, :root .foo {}
 ```

--- a/hacks/_posts/2019-03-26-yahoo-2.md
+++ b/hacks/_posts/2019-03-26-yahoo-2.md
@@ -9,7 +9,7 @@ contributor: Mark Robbins
 ---
 
 ```css
-@media screen yahoo{ .foo }
+@media screen yahoo{ .foo {} }
 ```
 
 Yahoo & AOL remove invalid media query selectors so will render the above as `@media screen {}`. Yahoo doesn't support `max-device-width` which makes it tricky to split mobile but we can use `max-width`.

--- a/hacks/_posts/2019-04-01-gmail-ios.md
+++ b/hacks/_posts/2019-04-01-gmail-ios.md
@@ -9,5 +9,5 @@ contributor: Jay Oram
 ---
 
 ```css
-@supports (-webkit-overflow-scrolling:touch) and (color:#ffff)
+@supports (-webkit-overflow-scrolling:touch) and (color:#ffff) {}
 ```

--- a/hacks/_posts/2019-06-13-thunderbird.md
+++ b/hacks/_posts/2019-06-13-thunderbird.md
@@ -10,8 +10,6 @@ contributor: Arfon Davis
 
 ```css
 @media screen and (-moz-device-pixel-ratio){
-  class {
-    // add styles here
-  }
+  .foo {}
 }
 ```

--- a/hacks/_posts/2020-02-19-ios-mail-13.md
+++ b/hacks/_posts/2020-02-19-ios-mail-13.md
@@ -9,7 +9,7 @@ contributor: Mark Robbins
 ---
 
 ```css
-[class^="apple-mail"] .foo
+[class^="apple-mail"] .foo {}
 ```
 
 Also targets Apple Mail 12.4 on desktop.

--- a/hacks/_posts/2021-06-14-ios-mail-15.md
+++ b/hacks/_posts/2021-06-14-ios-mail-15.md
@@ -9,7 +9,7 @@ contributor: Mark Robbins
 ---
 
 ```css
-@supports (-webkit-overflow-scrolling:touch) and (aspect-ratio: 1 / 1) { .foo }
+@supports (-webkit-overflow-scrolling:touch) and (aspect-ratio: 1 / 1) { .foo {} }
 ```
 
 `-webkit-overflow-scrolling:touch` is only supported on mobile devices.

--- a/hacks/_posts/2021-10-29-comcast-webmail.md
+++ b/hacks/_posts/2021-10-29-comcast-webmail.md
@@ -9,7 +9,7 @@ contributor: Mark Robbins
 ---
 
 ```css
-.mail-detail-content .foo
+.mail-detail-content .foo {}
 ```
 
 Comcast wraps code with `class="mail-detail-content"`. This also targets Libero.

--- a/hacks/_posts/2021-10-29-libero.md
+++ b/hacks/_posts/2021-10-29-libero.md
@@ -9,7 +9,7 @@ contributor: Mark Robbins
 ---
 
 ```css
-.mail-detail-content .foo
+.mail-detail-content .foo {}
 ```
 
 Libero wraps code with `class="mail-detail-content"`. This also targets Comcast.

--- a/hacks/_posts/2022-08-15-seznam.cz.md
+++ b/hacks/_posts/2022-08-15-seznam.cz.md
@@ -9,7 +9,7 @@ contributor: Devika Sujith
 ---
 
 ```css
-  blockquote[data-color] + .foo
+blockquote[data-color] + .foo {}
 ```
 
 By adding `blockquote` before the targetted class, we can hook into the appended `data-color` attribute to access it.


### PR DESCRIPTION
While working on #35 I noticed some inconsistencies in CSS hacks:

- Not all selectors or at-rules end with a declaration block
- Invalid CSS comment
- `class` being used instead of `.foo`

This PR updates CSS hacks to follow the same formats, which could make it easier for whoever uses the new API in #34. This is something can be enforced for new hacks going forward.

What I am unsure of is hacks that include multiple rulesets like this one:
https://github.com/dylanatsmith/howtotarget/blob/main/hacks/_posts/2019-03-26-thunderbird.md

Should each ruleset be in its own code fence? Or is it enough to end each selector with a declaration block?